### PR TITLE
Don't update the entry and expiration dates

### DIFF
--- a/system/expressionengine/third_party/mx_title_control/ext.mx_title_control.php
+++ b/system/expressionengine/third_party/mx_title_control/ext.mx_title_control.php
@@ -239,6 +239,13 @@ class Mx_title_control_ext
 				unset($meta['author_id']);
 				unset($meta['status']);
 
+				/*
+				 * Fix for Low Events conflict where the entry and expiration dates are changed back after LE updated them
+				 * @author: Lodewijk Schutte (gotolow.com)
+				 */
+				unset($meta['entry_date']);
+				unset($meta['expiration_date']);
+
 				ee()->db->where('entry_id', $entry_id);
 				ee()->db->update('channel_titles', $meta);
 			}


### PR DESCRIPTION
This fixes an issue with Low Events, see https://getsatisfaction.com/low/topics/updating-event-doesnt-update-entry-expiration-dates