### PR TITLE
Fix for #7 (Channel Form entries always return empty string for url_title)

### DIFF
--- a/system/expressionengine/third_party/mx_title_control/ext.mx_title_control.php
+++ b/system/expressionengine/third_party/mx_title_control/ext.mx_title_control.php
@@ -229,6 +229,7 @@ class Mx_title_control_ext
 
 
 					ee()->api_channel_entries->entry_id = $entry_id;
+					ee()->api_channel_entries->channel_id = $channel_id;
 					$meta['url_title'] = ee()->api_channel_entries->_validate_url_title($url_title_name_out, $meta['title'], true);
 				}
 


### PR DESCRIPTION
As per the issue above, this fix ensures that the channel_id is set when users are submitting through a front-end Channel Form and URL titles are thus correctly set.
