### PR TITLE
Fix issue that causes publish page validation error "The Title field is required." in EE 2.10.1

### DIFF
--- a/system/expressionengine/third_party/mx_title_control/ext.mx_title_control.php
+++ b/system/expressionengine/third_party/mx_title_control/ext.mx_title_control.php
@@ -375,7 +375,7 @@ class Mx_title_control_ext
 				{
 					if (trim($this->settings['title_pattern_'.$channel_id])  !='')
 					{
-						$out .= 'if ($("[name=\'title\'").val() == "") {$("[name=\'title\'").val("auto_replace");}
+						$out .= 'if ($("[name=\'title\']").val() == "") {$("[name=\'title\']").val("auto_replace");}
 								$("#hold_field_title").hide();
 
                                  var _oldShow = $.fn.show;


### PR DESCRIPTION
There was an error in the JS that selected and put a placeholder in empty title fields.