### PR TITLE
Fix for max_title value not being applied when publishing entries

### DIFF
--- a/system/expressionengine/third_party/mx_title_control/ext.mx_title_control.php
+++ b/system/expressionengine/third_party/mx_title_control/ext.mx_title_control.php
@@ -436,7 +436,7 @@ class Mx_title_control_ext
 
 				if ($max_title  != 100)
 				{
-					$out .= '$("#title").attr("maxlength", "'.$max_title.'");';
+					$out .= '$("[name=\'title\']").attr("maxlength", "'.$max_title.'");';
 				}
 
 				if ($max_url_title  != 75)


### PR DESCRIPTION
Changed title selector to select by name attribute instead of id. Tested in EE 2.9.2+