### PR TITLE
Fix a typo in the label for the update URL Title checkbox.

### DIFF
--- a/system/expressionengine/third_party/mx_title_control/language/english/lang.mx_title_control.php
+++ b/system/expressionengine/third_party/mx_title_control/language/english/lang.mx_title_control.php
@@ -28,7 +28,7 @@ $lang = array(
 ,'title_pattern' => 'Title Pattern'
 ,'url_title_pattern' => 'URL Title Pattern'
 ,'update_title' => 'Update all entries with new Title?'
-,'update_url_title' => 'Update alL entries with new URL Title?'
+,'update_url_title' => 'Update all entries with new URL Title?'
 
 /* END */
 ,''=>''


### PR DESCRIPTION
Just a simple typo fix.
